### PR TITLE
libvrc: implementing maskvalues and nbits

### DIFF
--- a/lib/libvrc/src/ast/bitslice.rs
+++ b/lib/libvrc/src/ast/bitslice.rs
@@ -35,7 +35,8 @@ use crate::token::TokenStream;
 
 /// Represents a bitslice of a [Field]
 ///
-/// The field corresponds to the slice `[start..end]` of the [Field]
+/// The field corresponds to the slice `[start, end]` of the [Field]
+/// The end bit is including `[start..=end]`
 #[derive(PartialEq, Clone)]
 pub struct BitSlice {
     /// the start bit
@@ -46,6 +47,25 @@ pub struct BitSlice {
     pub name: String,
     /// where it was defined
     pub pos: TokenStream,
+}
+
+impl BitSlice {
+    /// constructs the mask value of the bit slice
+    ///
+    /// # Example
+    /// start = 0, end = 3 -> 0xf
+    pub fn mask_value(&self) -> u64 {
+        let mut mask = 0;
+        for i in self.start..=self.end {
+            mask |= 1 << i;
+        }
+        mask
+    }
+
+    /// returns the number of bits this slice covers
+    pub fn nbits(&self) -> u64 {
+        self.end - self.start + 1
+    }
 }
 
 /// Implementation of the [Display] trait for [BitSlice]
@@ -111,8 +131,8 @@ impl AstNode for BitSlice {
         // Notes:       --
         // --------------------------------------------------------------------------------------
 
-        if self.name.is_ascii() {
-            let msg = format!("constant `{}` should have an upper case name", self.name);
+        if !self.name.is_ascii() {
+            let msg = format!("constant `{}` should be in ASCII", self.name);
             let hint = format!(
                 "convert the identifier to ASCII: `{}`",
                 self.name.to_ascii_uppercase()

--- a/lib/libvrc/src/ast/field.rs
+++ b/lib/libvrc/src/ast/field.rs
@@ -47,12 +47,28 @@ pub struct Field {
     pub name: String,
     /// a reference to the state where the field is (base + offset)
     pub stateref: Option<(String, u64)>,
-    /// the size of the field in bits
+    /// the size of the field in bytes
     pub length: u64,
     /// a vector of [BitSlice] representing the bitlayout
     pub layout: Vec<BitSlice>,
     /// the position where this field was defined
     pub pos: TokenStream,
+}
+
+impl Field {
+    /// constructs the mask value of the bit slices in the field
+    pub fn mask_value(&self) -> u64 {
+        let mut maskval = 0;
+        for s in &self.layout {
+            maskval |= s.mask_value();
+        }
+
+        maskval
+    }
+
+    pub fn nbits(&self) -> u64 {
+        self.length * 8
+    }
 }
 
 /// Implementation of the [Display] trait for [Field]


### PR DESCRIPTION
Implementing methods for the Ast::Field and Ast::BitSlice to obtain
the mask_value, a bit pattern that masks the invalid bits of the
field, and nbits() function to obtain the number of bits the field
and bitslice has.

Signed-off-by: Reto Achermann <achreto@cs.ubc.ca>