### PR TITLE
lib/velosiast: add some error checks for synth special functions

### DIFF
--- a/lib/velosiast/src/ast/method.rs
+++ b/lib/velosiast/src/ast/method.rs
@@ -566,6 +566,18 @@ impl VelosiAstMethod {
         }
     }
 
+    fn check_not_synth(&self, issues: &mut VelosiAstIssues) {
+        if self.is_synth {
+            let msg = "this special method should not be synth";
+            let hint = "remove the `synth`";
+            let err = VelosiAstErrBuilder::err(msg.to_string())
+                .add_hint(hint.to_string())
+                .add_location(self.loc.from_self_with_subrange(0..1))
+                .build();
+            issues.push(err);
+        }
+    }
+
     fn check_special_methods(&self, issues: &mut VelosiAstIssues) {
         match self.ident().as_str() {
             "translate" => {
@@ -575,6 +587,7 @@ impl VelosiAstMethod {
                     FN_SIG_TRANSLATE,
                     &[("va", VelosiAstTypeInfo::VirtAddr)],
                 );
+                self.check_not_synth(issues);
             }
             "matchflags" => {
                 // fn matchflags(flgs: flags) -> bool
@@ -584,6 +597,7 @@ impl VelosiAstMethod {
                     FN_SIG_MATCHFLAGS,
                     &[("flgs", VelosiAstTypeInfo::Flags)],
                 );
+                self.check_not_synth(issues);
             }
             "map" => {
                 // fn map(va: vaddr, sz: size, flgs: flags, pa: paddr)

--- a/lib/velosiast/src/error.rs
+++ b/lib/velosiast/src/error.rs
@@ -545,7 +545,7 @@ impl Display for VelosiAstIssues {
         if self.num_errors > 0 {
             writeln!(
                 f,
-                "{}{} could not compile due to {} previous errors; {} warnigns emitted",
+                "{}{} could not compile due to {} previous errors; {} warnings emitted",
                 red("error"),
                 ":".bold(),
                 self.num_errors,

--- a/lib/velosisynth/src/error.rs
+++ b/lib/velosisynth/src/error.rs
@@ -472,7 +472,7 @@ impl Display for VelosiSynthIssues {
         if self.num_errors > 0 {
             writeln!(
                 f,
-                "{}{} could not compile due to {} previous errors; {} warnigns emitted",
+                "{}{} could not compile due to {} previous errors; {} warnings emitted",
                 red("error"),
                 ":".bold(),
                 self.num_errors,


### PR DESCRIPTION
I think one small user experience thing is that for this:
```rust
    fn matchflags(flgs : flags) -> bool
        requires (state.pte.present == 1);
```
it will say:
```rust
error: method with no body must be declared abstract or synth.
     --> ../../examples/test.vrs:54:5
      |
   54 |      fn matchflags(flgs : flags) -> bool
      |      ^^ make this an `abstract fn` or `synth fn`
error: could not compile due to 1 previous errors; 0 warnings emitted
```

But now if you add `synth`:

```rust
error: this special method should not be synth
     --> ../../examples/test.vrs:54:5
      |
   54 |      synth fn matchflags(flgs : flags) -> bool
      |      ^^^^^ remove the `synth`
error: could not compile due to 1 previous errors; 0 warnings emitted
```

So maybe I could remove this if you think that's an issue?