### PR TITLE
Fix Crash with Register Size Check

### DIFF
--- a/lib/velosiast/src/ast/interface.rs
+++ b/lib/velosiast/src/ast/interface.rs
@@ -569,7 +569,8 @@ impl VelosiAstInterfaceMemoryField {
         utils::check_snake_case(&mut issues, &ident);
 
         // check the size
-        let size = utils::check_field_size(&mut issues, pt.size, &pt.loc);
+        let size_loc = pt.loc.from_self_with_subrange(7..8);
+        let size = utils::check_field_size(&mut issues, pt.size, &size_loc);
 
         // convert the base region, check whether it exists
         let base = VelosiAstIdentifier::from(pt.base);
@@ -604,7 +605,7 @@ impl VelosiAstInterfaceMemoryField {
             let hint = format!("Change offset to be a multiple of {size}");
             let err = VelosiAstErrBuilder::err(msg.to_string())
                 .add_hint(hint)
-                .add_location(pt.loc.from_self_with_subrange(7..8))
+                .add_location(pt.loc.from_self_with_subrange(5..6))
                 .build();
             issues.push(err);
         }
@@ -786,7 +787,8 @@ impl VelosiAstInterfaceMmioField {
         utils::check_snake_case(&mut issues, &ident);
 
         // check the size
-        let size = utils::check_field_size(&mut issues, pt.size, &pt.loc);
+        let size_loc = pt.loc.from_self_with_subrange(7..8);
+        let size = utils::check_field_size(&mut issues, pt.size, &size_loc);
 
         // convert the base region, check whether it exists
         let base = VelosiAstIdentifier::from(pt.base);
@@ -821,7 +823,7 @@ impl VelosiAstInterfaceMmioField {
             let hint = format!("Change offset to be a multiple of {size}");
             let err = VelosiAstErrBuilder::err(msg.to_string())
                 .add_hint(hint)
-                .add_location(pt.loc.from_self_with_subrange(7..8))
+                .add_location(pt.loc.from_self_with_subrange(5..6))
                 .build();
             issues.push(err);
         }
@@ -1046,7 +1048,8 @@ impl VelosiAstInterfaceRegisterField {
         utils::check_snake_case(&mut issues, &ident);
 
         // check the size
-        let size = utils::check_field_size(&mut issues, pt.size, &pt.loc);
+        let size_loc = pt.loc.from_self_with_subrange(3..4);
+        let size = utils::check_field_size(&mut issues, pt.size, &size_loc);
 
         // create dummy memory field
         let n = Self::new(ident.clone(), size, vec![], vec![], vec![], pt.loc.clone());

--- a/lib/velosiast/src/ast/state.rs
+++ b/lib/velosiast/src/ast/state.rs
@@ -103,7 +103,8 @@ impl VelosiAstStateMemoryField {
         utils::check_snake_case(&mut issues, &ident);
 
         // check the size
-        let size = utils::check_field_size(&mut issues, pt.size, &pt.loc);
+        let size_loc = pt.loc.from_self_with_subrange(7..8);
+        let size = utils::check_field_size(&mut issues, pt.size, &size_loc);
 
         // the offset should be aligned to the size
         let offset = pt.offset;
@@ -113,7 +114,7 @@ impl VelosiAstStateMemoryField {
             let hint = format!("Change offset to be a multiple of {size}");
             let err = VelosiAstErrBuilder::err(msg.to_string())
                 .add_hint(hint)
-                .add_location(pt.loc.from_self_with_subrange(7..8))
+                .add_location(pt.loc.from_self_with_subrange(5..6))
                 .build();
             issues.push(err);
         }
@@ -271,7 +272,8 @@ impl VelosiAstStateRegisterField {
         utils::check_snake_case(&mut issues, &ident);
 
         // check the size
-        let size = utils::check_field_size(&mut issues, pt.size, &pt.loc);
+        let size_loc = pt.loc.from_self_with_subrange(3..4);
+        let size = utils::check_field_size(&mut issues, pt.size, &size_loc);
 
         // convert the slices
         let mut layout = Vec::new();

--- a/lib/velosiast/src/utils.rs
+++ b/lib/velosiast/src/utils.rs
@@ -156,23 +156,28 @@ pub fn check_addressing_width(issues: &mut VelosiAstIssues, w: u64, loc: VelosiT
 }
 
 /// checks whether the identifier is in snake_case
-pub fn check_field_size(issues: &mut VelosiAstIssues, size: u64, loc: &VelosiTokenStream) -> u64 {
+pub fn check_field_size(
+    issues: &mut VelosiAstIssues,
+    size: u64,
+    size_loc: &VelosiTokenStream,
+) -> u64 {
     if ![1, 2, 4, 8].contains(&size) {
-        if [8, 16, 32, 64].contains(&size) {
-            let msg = format!("Size in bits given, bytes expected. Converting to {size}");
+        if [16, 32, 64].contains(&size) {
+            let bytes = size / 8;
+            let msg = format!("Size in bits given, bytes expected. Converting to {bytes} bytes.");
             let hint = "Change the size information to one of 1, 2, 4, 8.";
             let err = VelosiAstErrBuilder::warn(msg)
                 .add_hint(hint.to_string())
-                .add_location(loc.from_self_with_subrange(7..8))
+                .add_location(size_loc.clone())
                 .build();
             issues.push(err);
-            return size / 8;
+            return bytes;
         } else {
             let msg = format!("Unsupported size of the memory field: {size}");
             let hint = "Change the size information to one of 1, 2, 4, 8.";
             let err = VelosiAstErrBuilder::err(msg)
                 .add_hint(hint.to_string())
-                .add_location(loc.from_self_with_subrange(7..8))
+                .add_location(size_loc.clone())
                 .build();
             issues.push(err);
         }


### PR DESCRIPTION
Having a field such as:

```rust
  reg test [ 7 ] {
    ... 
  }
```

Crashes with the message:

```
thread 'main' panicked at 'Cannot create subrange outside of the current range', /Users/rmehri01/.cargo/git/checkouts/rust-tokstream-2c2b0fab
1cee467d/caeb677/src/lib.rs:141:13
```

Due to assuming that the different types of fields have the size in the same place. 

This also fixes an issue with the offset being pointed to is at the wrong place:

```rust
  mem test [ base, 1, 8 ] {
    ...
  }
```

Produces:

```rust
error: Offset is not a multiple of size size of the memory field
     --> ../../examples/x86_64_pagetable.vrs:155:29
      |
  155 |          mem test [ base, 1, 8 ] {
      |                              ^ Change offset to be a multiple of 8
```

But this is the size, not the offset.