### PR TITLE
Minor fixes to rust codegen

### DIFF
--- a/lib/velosicodegen/src/rust/field.rs
+++ b/lib/velosicodegen/src/rust/field.rs
@@ -161,8 +161,9 @@ fn add_struct_impl(scope: &mut CG::Scope, field: &VelosiAstInterfaceField) {
     imp.new_fn("new")
         .vis("pub")
         .doc(&format!("creates a new {} field value", field.ident()))
+        .arg("val", num_to_rust_type(field.nbits()))
         .ret(CG::Type::new("Self"))
-        .line("Self { val: 0 }");
+        .line("Self { val }");
 
     // add the get/set functions
     for sl in field.layout() {
@@ -177,7 +178,7 @@ fn add_default_impl(scope: &mut CG::Scope, field: &VelosiAstInterfaceField) {
 
     imp.new_fn("default")
         .ret(CG::Type::new("Self"))
-        .line("Self::new()");
+        .line("Self::new(0)");
 }
 
 /// generates the field value interface

--- a/lib/velosicodegen/src/rust/utils.rs
+++ b/lib/velosicodegen/src/rust/utils.rs
@@ -267,7 +267,8 @@ pub fn op_to_rust_expr(
         }
         VelosiOperation::InsertField(field, arg) => {
             format!(
-                "self.interface.write_{field}({});",
+                "let {field} = {}::new({});\n{field}\n",
+                to_struct_name(field, Some("Field")),
                 opexpr_to_rust_expr(arg, ast, method)
             )
         }


### PR DESCRIPTION
- Get generated code compiling again after new configuration sequences
- Add assertions to `map`/`unmap`/`protect`
- Add `free` in `unmap_table`