### PR TITLE
Update C codegen with higher-level composition

### DIFF
--- a/lib/velosicodegen/src/c/mod.rs
+++ b/lib/velosicodegen/src/c/mod.rs
@@ -32,6 +32,7 @@ use std::path::PathBuf;
 use crustal as C;
 
 use velosiast::{VelosiAst, VelosiAstUnit};
+use velosicomposition::Relations;
 
 use crate::VelosiCodeGenError;
 
@@ -115,6 +116,7 @@ impl BackendC {
 
     pub fn generate_units(&self, ast: &VelosiAst) -> Result<(), VelosiCodeGenError> {
         let mut srcdir = self.outdir.clone();
+        let relations = Relations::from_ast(ast);
 
         for unit in ast.units() {
             match unit {
@@ -124,12 +126,14 @@ impl BackendC {
                         continue;
                     }
                     srcdir.push(segment.ident().to_lowercase());
-                    segment::generate(segment, &srcdir).expect("code generation failed\n");
+                    segment::generate(segment, &relations, &srcdir)
+                        .expect("code generation failed\n");
                     srcdir.pop();
                 }
                 VelosiAstUnit::StaticMap(staticmap) => {
                     srcdir.push(staticmap.ident().to_lowercase());
-                    staticmap::generate(ast, staticmap, &srcdir).expect("code generation failed\n");
+                    staticmap::generate(ast, staticmap, &relations, &srcdir)
+                        .expect("code generation failed\n");
                     srcdir.pop();
                 }
                 VelosiAstUnit::Enum(e) => {

--- a/lib/velosicodegen/src/c/utils.rs
+++ b/lib/velosicodegen/src/c/utils.rs
@@ -83,7 +83,40 @@ pub trait UnitUtils {
         format!("{}_{}", self.my_ident().to_ascii_lowercase(), op.ident())
     }
 
+    fn to_op_fn_name_table(&self, op: &VelosiAstMethod) -> String {
+        format!(
+            "{}_{}_table",
+            self.my_ident().to_ascii_lowercase(),
+            op.ident()
+        )
+    }
+
+    fn to_op_fn_name_one(&self, op: &VelosiAstMethod) -> String {
+        format!(
+            "{}_{}_one",
+            self.my_ident().to_ascii_lowercase(),
+            op.ident()
+        )
+    }
+
+    fn to_op_fn_name_on_unit(&self, op: &VelosiAstMethod, variant_unit: &VelosiAstUnit) -> String {
+        format!(
+            "{}_{}_{}",
+            self.my_ident().to_ascii_lowercase(),
+            op.ident(),
+            variant_unit.ident().to_ascii_lowercase(),
+        )
+    }
+
     fn translate_fn_name(&self) -> String {
+        format!("{}_translate", self.my_ident().to_ascii_lowercase())
+    }
+
+    fn valid_fn_name(&self) -> String {
+        format!("{}_valid", self.my_ident().to_ascii_lowercase())
+    }
+
+    fn resolve_fn_name(&self) -> String {
         format!("{}_resolve", self.my_ident().to_ascii_lowercase())
     }
 
@@ -256,7 +289,11 @@ pub trait UnitUtils {
             },
             Quantifier(_i) => panic!("don't know how to handle quantifier"),
             FnCall(i) => C::Expr::fn_call(i.ident(), vec![]),
-            IfElse(_i) => panic!("don't know how to handle ifelse"),
+            IfElse(i) => C::Expr::ternary(
+                self.expr_to_cpp(var_mappings, &i.cond),
+                self.expr_to_cpp(var_mappings, &i.then),
+                self.expr_to_cpp(var_mappings, &i.other),
+            ),
             Slice(_i) => panic!("don't know how to handle slices"),
             Range(_i) => panic!("don't know how to handle range"),
         }

--- a/lib/velosicodegen/src/rust/staticmap.rs
+++ b/lib/velosicodegen/src/rust/staticmap.rs
@@ -305,12 +305,12 @@ fn add_higher_order_fn(
 
             let mut while_block = CG::Block::new(&format!("while sz >= {:#x}", base_page_size));
             while_block.line(format!(
-                "let unmapped = self.{}_one({});",
+                "let changed = self.{}_one({});",
                 op_name,
                 utils::params_to_args_list(&op.params)
             ));
-            while_block.line("sz -= unmapped;");
-            while_block.line("va += unmapped as u64;");
+            while_block.line("sz -= changed;");
+            while_block.line("va += changed as u64;");
             op_fn.push_block(while_block);
             op_fn.line("");
 


### PR DESCRIPTION
Gets the C codegen up to date with the changes in #108, there is quite a bit of duplication and the Rust codegen doesn't use many Rust specific features, so we may consider having one codegen AST that is common to both to reduce the duplication in the future.

Part of #80 